### PR TITLE
Replace Blockly.utils.replaceMessageReferences.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export class FieldTextBox extends Blockly.FieldMultilineInput {
    * @nocollapse
    */
   static fromJson(options) {
-    const text = Blockly.utils.replaceMessageReferences(options['text']);
+    const text = Blockly.utils.parsing.replaceMessageReferences(options['text']);
     return new FieldTextBox(text, undefined, options);
   }
 


### PR DESCRIPTION
Blockly.utils.replaceMessageReferences was deprecated on December 2021 and will be deleted on December 2022.
Use Blockly.utils.parsing.replaceMessageReferences instead.